### PR TITLE
Fix inference input handling for bytes

### DIFF
--- a/data_assets/inference.py
+++ b/data_assets/inference.py
@@ -15,6 +15,8 @@ def model_fn(model_dir):
         return pickle.load(f)
 
 def input_fn(input_data, content_type):
+    if isinstance(input_data, bytes):
+        input_data = input_data.decode("utf-8")
     df = pd.read_csv(StringIO(input_data), header=None)
     df.columns = FEATURE_COLUMNS
     return df


### PR DESCRIPTION
## Summary
- handle byte strings in inference input_fn

## Testing
- `python - <<'PY'
import importlib.util
spec=importlib.util.spec_from_file_location('inference','data_assets/inference.py')
inf=importlib.util.module_from_spec(spec);spec.loader.exec_module(inf)
print('input_fn handles bytes ->', not inf.input_fn(b"1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19\n", 'text/csv').empty)
PY`

------
https://chatgpt.com/codex/tasks/task_e_683fa7f02bbc832c840877fe1ed09ef7